### PR TITLE
SEAR-2357: Updated the Go version from 1.18 to 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: cimg/go:1.18.3
+      - image: cimg/go:1.20.0
     working_directory: /tmp/geocollection
     steps:
       - checkout
@@ -10,7 +10,7 @@ jobs:
       - run: make lint
   test:
     docker:
-      - image: cimg/go:1.18.3
+      - image: cimg/go:1.20.0
     working_directory: /tmp/geocollection
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.out
 vendor/
 coverage.txt
+.idea/

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 SpotHero
+Copyright 2023 SpotHero
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/geocollection.go
+++ b/geocollection.go
@@ -1,4 +1,4 @@
-// Copyright 2022 SpotHero
+// Copyright 2023 SpotHero
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/geocollection_test.go
+++ b/geocollection_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 SpotHero
+// Copyright 2023 SpotHero
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spothero/geocollection
 
-go 1.18
+go 1.20
 
 require (
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551

--- a/test_helpers/mockcollection.go
+++ b/test_helpers/mockcollection.go
@@ -1,4 +1,4 @@
-// Copyright 2022 SpotHero
+// Copyright 2023 SpotHero
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Issue Link**
[SEAR-2357](https://spothero.atlassian.net/browse/SEAR-2357)

**Description**
- Updated the Go version from 1.18 to 1.20


[SEAR-2357]: https://spothero.atlassian.net/browse/SEAR-2357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ