### PR TITLE
SEAR-3612 Fix linting errors for golangci-lint version 1.59.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,12 @@
 run:
-  deadline: 5m
+  timeout: 5m
   tests: true
 linters:
   enable:
     - revive
     - gofmt
     - staticcheck
-    - vet
+    - govet
     - misspell
     - ineffassign
     - errcheck
@@ -15,5 +15,7 @@ linters:
 
 linters-settings:
   govet:
-    check-shadowing: true
+    settings:
+      shadow:
+        strict: true
     enable-all: true


### PR DESCRIPTION
**Issue Link**
https://spothero.atlassian.net/browse/SEAR-3612

**Description**
This PR fixes all linting errors after upgrading our `golangci-lint` version to `1.59.1`. Depends on https://github.com/spothero/mdw/pull/370
